### PR TITLE
Fixed issue locating LocalizedStrings.js

### DIFF
--- a/ReactNativeLocalization.podspec
+++ b/ReactNativeLocalization.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'React'
 
-  s.preserve_paths      = 'CHANGELOG.md', 'LICENSE', 'package.json', 'LocalizedStrings.js'
-  s.source_files        = '**/*.{h,m}'
+  s.preserve_paths      = 'CHANGELOG.md', 'LICENSE', 'package.json'
+  s.source_files        = '**/*.{h,m}', 'lib/LocalizedStrings.js'
   s.exclude_files       = 'android/**/*'
 end


### PR DESCRIPTION
LocalizedStrings.js has been moved from root to /lib.  This change will fix an issue where RN fails to load the module.